### PR TITLE
CancelMovement Setting in Offhand

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # Wurst+3
 
-[Discord](discord.gg/hvnZePKQHx) | [Donate](https://paypal.me/trvsf) | [Download](https://github.com/TrvsF/wurst-plus-three/releases/latest)
+[Discord](https://discord.com/invite/hvnZePKQHx) | [Donate](https://paypal.me/trvsf) | [Download](https://github.com/TrvsF/wurst-plus-three/releases/latest)
 
 1.12.2 forge minecraft client
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # Wurst+3
 
-[Discord](https://discord.gg/hvnZePKQHx) | [Donate](https://paypal.me/trvsf) | [Download](https://github.com/TrvsF/wurst-plus-three/releases/latest)
+[Discord](discord.gg/hvnZePKQHx) | [Donate](https://paypal.me/trvsf) | [Download](https://github.com/TrvsF/wurst-plus-three/releases/latest)
 
 1.12.2 forge minecraft client
 


### PR DESCRIPTION
On 2b2t, you cannot switch items whilst moving, therefore Offhand will not work. This PR adds a CancelMovement Setting which cancels the MoveEvent until the Totem has been swapped and then resumes.